### PR TITLE
Additional meta data from schedule parser

### DIFF
--- a/lib/soda_xml_team/schedule.rb
+++ b/lib/soda_xml_team/schedule.rb
@@ -18,7 +18,11 @@ module SodaXmlTeam
 
         event.css('event-metadata').each do |eventmeta|
           row[:event_key] = eventmeta['event-key']
-          row[:start_date_time] = eventmeta['start-date-time']
+          row[:start_date_time] = DateTime.parse(eventmeta['start-date-time'])
+          row[:time_certainty] = eventmeta['time-certainty']
+          eventmeta.css('site name').each do |sitemeta|
+            row[:site] = sitemeta['full']
+          end
         end
         event.css('team team-metadata[alignment="away"]').each do |away_team|
           team_name = away_team.css('name').first

--- a/lib/soda_xml_team/version.rb
+++ b/lib/soda_xml_team/version.rb
@@ -1,3 +1,3 @@
 module SodaXmlTeam
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/spec/soda_xml_team_spec.rb
+++ b/spec/soda_xml_team_spec.rb
@@ -68,5 +68,25 @@ describe SodaXmlTeam do
       expect(output.length).to eq 82
     end
 
+    it 'has expected home team' do
+      expect(output[1][:home_team]).to eq 'Nashville Predators'
+    end
+
+    it 'has expected away team' do
+      expect(output[1][:away_team]).to eq 'Colorado Avalanche'
+    end
+
+    it 'has expected start date/time' do
+      expect(output[1][:start_date_time]).to eq DateTime.parse('October 8, 2009 7:00 PM CDT')
+    end
+
+    it 'has expected site' do
+      expect(output[1][:site]).to eq 'Sommet Center'
+    end
+
+    it 'has expected time certainty' do
+      expect(output[1][:time_certainty]).to eq 'certain'
+    end
+
   end
 end


### PR DESCRIPTION
- Adds the site of the event (name of the venue)
- Adds the time certainty value (if date is set, but time is not)
- Updates test suite
- Version bump to v1.0.8
