### PR TITLE
Allow start/end dates to be passed in as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ gem 'soda_xml_team'
 
 And then execute:
 
-    $ bundle
+```bash
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install soda_xml_team
+```bash
+$ gem install soda_xml_team
+```
 
 ## Usage
 
@@ -34,8 +38,8 @@ listing = soda.content_finder({
   league_id: 'l.nhl.com',
   team_id: 'l.nhl.com-t.19',
   type: 'schedule-single-team',
-  start_datetime: DateTime.parse('2010-01-01 00:00:00 CDT'),
-  end_datetime: DateTime.parse('2011-01-01 00:00:00 CDT')
+  start_datetime: '2010-01-01 00:00:00 CDT',
+  end_datetime: '2011-01-01 00:00:00 CDT'
 })
 
 # An array of documents matching your query
@@ -103,7 +107,6 @@ standings = SodaXmlTeam::Standings.parse_standings(standings_document)
 # This is now available as an array of values
 puts standings.inspect
 ```
-
 
 ## Contributing
 

--- a/lib/soda_xml_team/address.rb
+++ b/lib/soda_xml_team/address.rb
@@ -35,12 +35,18 @@ module SodaXmlTeam
         end
 
         # Start date/time
-        if options[:start_datetime].is_a? DateTime
+        if options[:start_datetime].is_a? String
+          options[:start_datetime] = DateTime.parse(options[:start_datetime])
+          path << "earliest-date-time=#{options[:start_datetime].strftime('%Y%m%dT%H%M%S%z')}"
+        elsif options[:start_datetime].is_a? DateTime
           path << "earliest-date-time=#{options[:start_datetime].strftime('%Y%m%dT%H%M%S%z')}"
         end
 
         # End date/time
-        if options[:end_datetime].is_a? DateTime
+        if options[:end_datetime].is_a? String
+          options[:end_datetime] = DateTime.parse(options[:end_datetime])
+          path << "latest-date-time=#{options[:end_datetime].strftime('%Y%m%dT%H%M%S%z')}"
+        elsif options[:end_datetime].is_a? DateTime
           path << "latest-date-time=#{options[:end_datetime].strftime('%Y%m%dT%H%M%S%z')}"
         end
 

--- a/lib/soda_xml_team/version.rb
+++ b/lib/soda_xml_team/version.rb
@@ -1,3 +1,3 @@
 module SodaXmlTeam
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/soda_xml_team.gemspec
+++ b/soda_xml_team.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Stephen Yeargin"]
   spec.email         = ["stephen@seatsha.re"]
   spec.summary       = %q{XML Team Sports On Demand API}
-  spec.description   = %q{A basic layer for interacting XML Team's Sports On Demand API (SODA)}
+  spec.description   = %q{A basic layer for interacting with XML Team's Sports On Demand API (SODA)}
   spec.homepage      = "https://github.com/seatshare/soda_xml_team"
   spec.license       = "MIT"
 

--- a/spec/soda_xml_team_spec.rb
+++ b/spec/soda_xml_team_spec.rb
@@ -35,6 +35,35 @@ describe "SodaXmlTeam" do
       expect(output[0][:team]).to eq "l.nhl.com-t.19"
     end
 
+    let(:input) {
+      {
+        sandbox: true,
+        league_id: 'l.nhl.com',
+        team_id: 'l.nhl.com-t.19',
+        type: 'schedule-single-team',
+        start_datetime: '2010-01-01 00:00:00 CDT',
+        end_datetime: '2011-01-01 00:00:00 CDT'
+      }
+    }
+    let(:output) { subject.content_finder(input) }
+
+    it 'has seven items with string timestamp' do
+      expect(output.length).to eq 7
+    end
+
+    it 'has attributes that match with string timestamp' do
+      expect(output[1][:title]).to eq "2010 Nashville Predators Schedule"
+      expect(output[1][:link]).to eq "http://soda.xmlteam.com/api-trial/getDocuments?doc-ids=xt.10860136-nas-sked"
+      expect(output[1][:document_id]).to eq "xt.10860136-nas-sked"
+      expect(output[1][:date]).to eq DateTime.parse('February 12, 2010 22:49 PM CDT')
+      expect(output[1][:publisher]).to eq "sportsnetwork.com"
+      expect(output[1][:priority]).to eq "normal"
+      expect(output[1][:sport]).to eq "15031000"
+      expect(output[1][:league]).to eq "l.nhl.com"
+      expect(output[1][:conference]).to eq "c.western"
+      expect(output[1][:team]).to eq "l.nhl.com-t.19"
+    end
+
   end
 
   describe '.get_document' do


### PR DESCRIPTION
Fixes #7

Prior to this PR, the implementation required that a `DateTime` object be passed in to the `content_finder` method's start/end date parameters. This PR allows users to pass in either a stirng or a `DateTime` object.
